### PR TITLE
Story-4 done

### DIFF
--- a/applications/services/tax_service.go
+++ b/applications/services/tax_service.go
@@ -6,4 +6,5 @@ import (
 
 type TaxServiceInterface interface {
 	CalculateTax(income float64, wht float64, allowances []schemas.Allowance) (float64, float64, error)
+	CalculateDetailedTax(income float64, wht float64, allowances []schemas.Allowance) ([]schemas.TaxLevel, float64, float64, error)
 }

--- a/applications/services/tax_service_impl.go
+++ b/applications/services/tax_service_impl.go
@@ -36,7 +36,7 @@ func (s *taxService) CalculateTax(income float64, wht float64, allowances []sche
 
 	incomeAfterDeduct := income - config.PersonalDeduction - allowancesDeduction
 	if incomeAfterDeduct < 0 {
-		return 0, 0, nil
+		incomeAfterDeduct = 0
 	}
 
 	tax := calculateProgressiveTax(incomeAfterDeduct)
@@ -52,17 +52,7 @@ func (s *taxService) CalculateTax(income float64, wht float64, allowances []sche
 }
 
 func calculateProgressiveTax(income float64) float64 {
-	brackets := []struct {
-		UpperBound float64
-		TaxRate    float64
-	}{
-		{150000, 0},
-		{500000, 0.1},
-		{1000000, 0.15},
-		{2000000, 0.2},
-		{math.MaxFloat64, 0.35},
-	}
-
+	brackets := getTaxBrackets()
 	tax := 0.0
 	previousUpperBound := 0.0
 
@@ -76,4 +66,85 @@ func calculateProgressiveTax(income float64) float64 {
 		break
 	}
 	return tax
+}
+
+func (s *taxService) CalculateDetailedTax(income, wht float64, allowances []schemas.Allowance) ([]schemas.TaxLevel, float64, float64, error) {
+    config, err := s.taxRepo.GetConfig()
+	if err != nil {
+		return nil, 0, 0, err
+	}
+
+	allowancesDeduction := 0.0
+	for _, allowance := range allowances {
+		if allowance.AllowanceType == "donation" {
+			if allowance.Amount > config.DonationDeductionMax {
+				allowancesDeduction += config.DonationDeductionMax
+			} else {
+				allowancesDeduction += allowance.Amount
+			}
+		}
+	}
+
+	incomeAfterDeduct := income - config.PersonalDeduction - allowancesDeduction
+	if incomeAfterDeduct < 0 {
+		incomeAfterDeduct = 0
+	}
+
+    taxLevels, tax := calculateProgressiveTaxWithDetails(incomeAfterDeduct)
+
+    netTax := tax - wht
+    taxRefund := 0.0
+	if netTax < 0 {
+		taxRefund = -netTax // Calculate refund as the negative of a negative tax value
+		netTax = 0
+	}
+
+    return taxLevels, netTax, taxRefund, nil
+
+}
+
+func calculateProgressiveTaxWithDetails(income float64) ([]schemas.TaxLevel, float64) {
+    brackets := getTaxBrackets()
+
+    detailResponse := []schemas.TaxLevel{
+        {Level: "0-150,000", Tax: 0.0},
+        {Level: "150,001-500,000", Tax: 0.0},
+        {Level: "500,001-1,000,000", Tax: 0.0},
+        {Level: "1,000,001-2,000,000", Tax: 0.0},
+        {Level: "2,000,001 ขึ้นไป", Tax: 0.0},
+    }
+
+    tax := 0.0
+	previousUpperBound := 0.0
+
+    for i, bracket := range brackets {
+		if income > bracket.UpperBound {
+            taxAmount := (bracket.UpperBound - previousUpperBound) * bracket.TaxRate
+			tax += taxAmount
+			previousUpperBound = bracket.UpperBound
+            detailResponse[i].Tax = taxAmount
+			continue
+		}
+		tax += (income - previousUpperBound) * bracket.TaxRate
+        detailResponse[i].Tax = (income - previousUpperBound) * bracket.TaxRate
+		break
+	}
+
+    return detailResponse, tax
+}
+
+func getTaxBrackets() ([]struct {
+    UpperBound float64
+    TaxRate    float64
+}) {
+    return []struct {
+        UpperBound float64
+        TaxRate    float64
+    }{
+        {150000, 0},
+        {500000, 0.1},
+        {1000000, 0.15},
+        {2000000, 0.2},
+        {math.MaxFloat64, 0.35},
+    }
 }

--- a/interfaces/endpoints/router.go
+++ b/interfaces/endpoints/router.go
@@ -17,7 +17,7 @@ func NewRouter(e *echo.Echo, taxControllerr *controllers.TaxController, adminCon
 
 	// Group for tax-related routes
 	taxGroup := e.Group("/tax")
-	taxGroup.POST("/calculations", taxControllerr.CalculateTax)
+	taxGroup.POST("/calculations", taxControllerr.CalculateDetailedTax)
 
 	// Group for admin-related routes
 	adminGroup := e.Group("/admin")

--- a/interfaces/schemas/tax_schema.go
+++ b/interfaces/schemas/tax_schema.go
@@ -34,3 +34,13 @@ type TaxCalculationResponse struct {
 type TaxCalculationRefundResponse struct {
 	TaxRefund float64 `json:"taxRefund"`
 }
+
+type TaxLevel struct {
+	Level string  `json:"level"`
+	Tax   float64 `json:"tax"`
+}
+
+type DetailedTaxCalculationResponse struct {
+	Tax      float64    `json:"tax"`
+	TaxLevel []TaxLevel `json:"taxLevel"`
+}


### PR DESCRIPTION
- Add `CalculateDetailedTax` to `tax_service`
- Add `CalculateDetailedTax` to `tax_controller.go`
- Add `DetailedTaxCalculationResponse` to `tax_schema`
- Continue to use `TaxCalculationRefundResponse`, which includes only the tax field, for responses that involve refunds.