### PR TITLE
Story-6 done

### DIFF
--- a/applications/services/tax_service.go
+++ b/applications/services/tax_service.go
@@ -7,4 +7,5 @@ import (
 type TaxServiceInterface interface {
 	CalculateTax(income float64, wht float64, allowances []schemas.Allowance) (float64, float64, error)
 	CalculateDetailedTax(income float64, wht float64, allowances []schemas.Allowance) ([]schemas.TaxLevel, float64, float64, error)
+	CalculateTaxFromCSV(records []schemas.CSVObjectFormat) (schemas.CSVResponse, error)
 }

--- a/applications/services/tax_service_impl.go
+++ b/applications/services/tax_service_impl.go
@@ -153,6 +153,50 @@ func calculateProgressiveTaxWithDetails(income float64) ([]schemas.TaxLevel, flo
 	return detailResponse, tax
 }
 
+func (s *taxService) CalculateTaxFromCSV(records []schemas.CSVObjectFormat) (schemas.CSVResponse, error) {
+	config, err := s.taxRepo.GetConfig()
+	if err != nil {
+		return schemas.CSVResponse{}, err
+	}
+
+	var response schemas.CSVResponse
+
+	for _, record := range records {
+		totalIncome := record.TotalIncome
+		wht := record.WHT
+		donation := record.Donation
+		k_receipt := record.KReceipt
+
+		if donation > config.DonationDeductionMax {
+			donation = config.DonationDeductionMax
+		}
+		if k_receipt > config.KReceiptDeductionMax {
+			k_receipt = config.KReceiptDeductionMax
+		}
+
+		totalIncomeAfterDeduct := totalIncome - (donation + k_receipt + config.PersonalDeduction)
+
+		if totalIncomeAfterDeduct < 0 {
+			totalIncomeAfterDeduct = 0
+		}
+
+		tax := calculateProgressiveTax(totalIncomeAfterDeduct)
+		netTax := tax - wht
+		if netTax < 0 {
+			response.Taxes = append(response.Taxes, schemas.CSVResponseMember{
+				TotalIncome: totalIncome,
+				TaxRefund:   -netTax,
+			})
+		} else {
+			response.Taxes = append(response.Taxes, schemas.CSVResponseMember{
+				TotalIncome: totalIncome,
+				Tax:         netTax,
+			})
+		}
+	}
+	return response, nil
+}
+
 func getTaxBrackets() []struct {
 	UpperBound float64
 	TaxRate    float64

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/gocarina/gocsv v0.0.0-20231116093920-b87c2d0e983a // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 // indirect
 	github.com/jackc/pgx/v5 v5.5.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gocarina/gocsv v0.0.0-20231116093920-b87c2d0e983a h1:RYfmiM0zluBJOiPDJseKLEN4BapJ42uSi9SZBQ2YyiA=
+github.com/gocarina/gocsv v0.0.0-20231116093920-b87c2d0e983a/go.mod h1:5YoVOkjYAQumqlV356Hj3xeYh4BdZuLE0/nRkf2NKkI=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 h1:L0QtFUgDarD7Fpv9jeVMgy/+Ec0mtnmYuImjTz6dtDA=

--- a/interfaces/endpoints/controllers/tax_controller.go
+++ b/interfaces/endpoints/controllers/tax_controller.go
@@ -1,7 +1,11 @@
 package controllers
 
 import (
+	"encoding/csv"
+	"io"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/labstack/echo/v4"
 	"github.com/thitiphum-bluesage/assessment-tax/applications/services"
@@ -72,6 +76,71 @@ func (tc *TaxController) CalculateDetailedTax(c echo.Context) error {
 	response := schemas.DetailedTaxCalculationResponse{
 		Tax:      netTax,
 		TaxLevel: taxLevel,
+	}
+	return c.JSON(http.StatusOK, response)
+}
+
+func (tc *TaxController) CalculateCSVTax(c echo.Context) error {
+	fileHeader, err := c.FormFile("taxFile")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Failed to get the file")
+	}
+
+	file, err := fileHeader.Open()
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to open the file")
+	}
+	defer file.Close()
+
+	csvReader := csv.NewReader(file)
+	headers, err := csvReader.Read()
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to read headers from CSV file")
+	}
+
+	columnIndex := make(map[string]int)
+	for i, header := range headers {
+		columnIndex[strings.ToLower(header)] = i
+	}
+
+	// {
+	// 	"totalincome": 0,
+	// 	"wht": 1,
+	// 	"donation": 2,
+	// 	"kreceipt": 3
+	// }
+
+	var taxRecords []schemas.CSVObjectFormat
+	for {
+		record, err := csvReader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to read record from CSV file")
+		}
+
+		var taxRecord schemas.CSVObjectFormat
+		if index, ok := columnIndex["totalincome"]; ok {
+			taxRecord.TotalIncome, _ = strconv.ParseFloat(record[index], 64)
+		}
+		if index, ok := columnIndex["wht"]; ok {
+			taxRecord.WHT, _ = strconv.ParseFloat(record[index], 64)
+		}
+		if index, ok := columnIndex["donation"]; ok {
+			taxRecord.Donation, _ = strconv.ParseFloat(record[index], 64)
+		}
+		// k-receipt will = 0 if not provided
+		if index, ok := columnIndex["k-receipt"]; ok {
+			taxRecord.KReceipt, _ = strconv.ParseFloat(record[index], 64)
+		}
+
+		taxRecords = append(taxRecords, taxRecord)
+	}
+
+	response, err := tc.taxService.CalculateTaxFromCSV(taxRecords)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.JSON(http.StatusOK, response)
 }

--- a/interfaces/endpoints/router.go
+++ b/interfaces/endpoints/router.go
@@ -18,6 +18,7 @@ func NewRouter(e *echo.Echo, taxControllerr *controllers.TaxController, adminCon
 	// Group for tax-related routes
 	taxGroup := e.Group("/tax")
 	taxGroup.POST("/calculations", taxControllerr.CalculateDetailedTax)
+	taxGroup.POST("/calculations/upload-csv", taxControllerr.CalculateCSVTax)
 
 	// Group for admin-related routes
 	adminGroup := e.Group("/admin")

--- a/interfaces/schemas/tax_schema.go
+++ b/interfaces/schemas/tax_schema.go
@@ -44,3 +44,20 @@ type DetailedTaxCalculationResponse struct {
 	Tax      float64    `json:"tax"`
 	TaxLevel []TaxLevel `json:"taxLevel"`
 }
+
+type CSVObjectFormat struct {
+	TotalIncome float64 `csv:"totalIncome"`
+	WHT         float64 `csv:"wht"`
+	Donation    float64 `csv:"donation"`
+	KReceipt    float64 `csv:"k-receipt"`
+}
+
+type CSVResponseMember struct {
+	TotalIncome float64 `json:"totalIncome"`
+	Tax         float64 `json:"tax,omitempty"`
+	TaxRefund   float64 `json:"taxRefund,omitempty"`
+}
+
+type CSVResponse struct {
+	Taxes []CSVResponseMember `json:"taxes"`
+}


### PR DESCRIPTION
This commit adds two key functions to support tax calculations from CSV data:

1. `CalculateTaxFromCSV` in the tax service:
   - Calculates taxes and refunds from CSV records.
   - Leverages existing tax brackets and deductions.

2. `CalculateCSVTax` in the tax controller:
   - Endpoint for CSV tax calculation submissions.
   - Parses CSV data and outputs structured JSON tax calculations.