### PR TITLE
Fix Docker Compose and enable Docker run with network

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,14 @@ RUN go mod download
 
 RUN go build -o main .
 
-FROM alpine:latest  
+FROM alpine:latest
 
 COPY --from=builder /go/src/app/main /main
+
+ENV DATABASE_URL=postgres://godou:1111@postgres:5432/ktaxes?sslmode=disable
+ENV PORT=8080
+ENV ADMIN_USERNAME=adminTax
+ENV ADMIN_PASSWORD=admin!
 
 EXPOSE 8080
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,13 @@ services:
       - "2000:5432"
     volumes:
       - ou_ktax:/var/lib/postgresql/data
+    networks:
+      - moon_sword
 
 volumes:
   ou_ktax:
     driver: local
+
+networks:
+  moon_sword:
+    external: true


### PR DESCRIPTION
### Complete tasks

- Fixed Docker Compose to include only the database service
- Make Dockerfile for the ktax app to run with the database using the `moon_sword` network