### PR TITLE
Adjust Docker for host network compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM alpine:latest
 
 COPY --from=builder /go/src/app/main /main
 
-ENV DATABASE_URL=postgres://godou:1111@postgres:5432/ktaxes?sslmode=disable
+ENV DATABASE_URL=postgres://godou:1111@localhost:2000/ktaxes?sslmode=disable
 ENV PORT=8080
 ENV ADMIN_USERNAME=adminTax
 ENV ADMIN_PASSWORD=admin!

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,13 +10,7 @@ services:
       - "2000:5432"
     volumes:
       - ou_ktax:/var/lib/postgresql/data
-    networks:
-      - moon_sword
 
 volumes:
   ou_ktax:
     driver: local
-
-networks:
-  moon_sword:
-    external: true


### PR DESCRIPTION
### Completed Tasks

- **Simplified Docker Compose**: Removed network settings and directly mapped PostgreSQL ports, streamlining the setup for host network compatibility.

- **Updated Dockerfile**: Modified `DATABASE_URL` for direct host connection, preparing the application for `docker run --network="host"`.